### PR TITLE
testing: implement svg mock for jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --transformIgnorePatterns \"node_modules/(?!@clientio)/\"",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+test('renders JointJS paper', () => {
+    render(<App />);
+    const paper = document.querySelector('.joint-paper');
+    expect(paper).toBeInTheDocument();
 });

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -3,3 +3,72 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+// Mock method which is not implemented in JSDOM
+window.SVGPathElement = jest.fn();
+
+beforeEach(()=>{
+
+    Object.defineProperty(global.SVGSVGElement.prototype, 'createSVGMatrix', {
+      writable: true,
+      value: jest.fn().mockImplementation(() => ({
+        martix: jest.fn(() => [[]]),
+        a: 0,
+        b: 0,
+        c: 0,
+        d: 0,
+        e: 0,
+        f: 0,
+        flipX: jest.fn().mockImplementation(() => global.SVGSVGElement),
+        flipY: jest.fn().mockImplementation(() => global.SVGSVGElement),
+        inverse: jest.fn().mockImplementation(() => global.SVGSVGElement),
+        multiply: jest.fn().mockImplementation(() => global.SVGSVGElement),
+        rotate: jest.fn().mockImplementation(() => ({
+          translate: jest.fn().mockImplementation(() => ({
+            rotate: jest.fn(),
+          })),
+        })),
+        rotateFromVector: jest.fn().mockImplementation(() => global.SVGSVGElement),
+        scale: jest.fn().mockImplementation(() => global.SVGSVGElement),
+        scaleNonUniform: jest.fn().mockImplementation(() => global.SVGSVGElement),
+        skewX: jest.fn().mockImplementation(() => global.SVGSVGElement),
+        skewY: jest.fn().mockImplementation(() => global.SVGSVGElement),
+        translate: jest.fn().mockImplementation(() => ({
+          multiply: jest.fn().mockImplementation(() => ({
+            multiply: jest.fn().mockImplementation(() => global.SVGSVGElement),
+          })),
+        })),
+      })),
+    });
+  
+    Object.defineProperty(global.SVGSVGElement.prototype, 'createSVGPoint', {
+      writable: true,
+      value: jest.fn().mockImplementation(() => ({
+        x: 0,
+        y: 0,
+        matrixTransform: jest.fn().mockImplementation(() => ({
+          x: 0,
+          y: 0,
+        })),
+      })),
+    });
+  
+    Object.defineProperty(global.SVGSVGElement.prototype, 'createSVGTransform', {
+      writable: true,
+      value: jest.fn().mockImplementation(() => ({
+        angle: 0,
+        matrix: {
+          a: 1,
+          b: 0,
+          c: 0,
+          d: 1,
+          e: 0,
+          f: 0,
+          multiply: jest.fn(),
+        },
+        setMatrix: jest.fn(),
+        setTranslate: jest.fn(),
+      })),
+    });
+
+});


### PR DESCRIPTION
- npm test script changed as `--transformIgnorePatterns` option is not available in create-react-app. This option should be available outside of create-react-app using `jest.config.js`
`window.SVGPathElement = jest.fn();` is a mock which fixes `TypeError: Cannot read property 'prototype' of undefined`
- added JointJS mocks from here (This was needed to fix errors related to `createSVGMatrix` is not a function)
https://gist.github.com/ahmad2smile/068e481d65b0cb82a7c9b9f1bc9d0ee0