### PR TITLE
chore: Use new Jest mocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This git repository is intended for instructional purposes. It is the source code that accompanies a JointJS+ blog post "Integration with React" which can be found [here](https://resources.jointjs.com/tutorial/react-ts).
 
-### Prerequisites  
+### Prerequisites
 
 To run the following code, you will need a [JointJS+ license](https://www.jointjs.com/license) that comes with the JointJS+ installable package file `joint-plus.tgz`.
 
@@ -45,6 +45,6 @@ You should be able to view the demo at `http://localhost:3000`.
 
 #### Note
 We have decided to keep the React import in our code for consistency reasons.
- 
+
 *Because the new JSX transform will automatically import the necessary react/jsx-runtime functions, React will no longer need to be in scope when you use JSX. This might lead to unused React imports in your code. It doesn’t hurt to keep them.*
 [Unused React imports](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#removing-unused-react-imports)

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",
     "sass": "^1.66.1",
-    "typescript": "~5.1.6",
+    "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test --transformIgnorePatterns \"node_modules/(?!@clientio)/\"",
+    "test": "react-scripts test --transformIgnorePatterns \"node_modules/(?!@joint)/\"",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -11,11 +11,12 @@
     "@types/node": "^16.11.43",
     "@types/react": "^18.0.15",
     "@types/react-dom": "^18.0.6",
+    "canvas": "^3.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",
     "sass": "^1.66.1",
-    "typescript": "^4.7.4",
+    "typescript": "~5.1.6",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react';
 import App from './App';
 
 test('renders JointJS paper', () => {
-    render(<App />);
-    const paper = document.querySelector('.joint-paper');
-    expect(paper).toBeInTheDocument();
+  render(<App />);
+  const paper = document.querySelector('.joint-paper');
+  expect(paper).toBeInTheDocument();
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import { dia, ui, shapes } from '@joint/plus';
+import { dia, shapes, ui } from '@joint/plus';
 import './App.scss';
 
 function App() {
@@ -10,41 +10,41 @@ function App() {
     const graph = new dia.Graph({}, { cellNamespace: shapes });
 
     const paper = new dia.Paper({
-        model: graph,
-        background: {
+      model: graph,
+      background: {
         color: '#F8F9FA',
-        },
-        frozen: true,
-        async: true,
-        sorting: dia.Paper.sorting.APPROX,
-        cellViewNamespace: shapes
+      },
+      frozen: true,
+      async: true,
+      sorting: dia.Paper.sorting.APPROX,
+      cellViewNamespace: shapes
     });
 
     const scroller = new ui.PaperScroller({
-        paper,
-        autoResizePaper: true,
-        cursor: 'grab'
+      paper,
+      autoResizePaper: true,
+      cursor: 'grab'
     });
 
     canvas.current.appendChild(scroller.el);
-    scroller.render().center(); 
+    scroller.render().center();
 
     const rect = new shapes.standard.Rectangle({
       position: { x: 100, y: 100 },
       size: { width: 100, height: 50 },
       attrs: {
-          label: {
-             text: 'Hello World'
-         }
-       }
+        label: {
+          text: 'Hello World'
+        }
+      }
     });
-  
+
     graph.addCell(rect);
     paper.unfreeze();
 
     return () => {
-        scroller.remove();
-        paper.remove();
+      scroller.remove();
+      paper.remove();
     };
   }, []);
 

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -165,4 +165,18 @@ beforeEach(() => {
         value: jest.fn().mockImplementation(createSVGRect),
     });
 
+    /**
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/checkVisibility
+     * @see https://github.com/jsdom/jsdom/issues/3695
+     * @description This method is not implemented in JSDOM yet.
+     * We are adding it only to SVGElement.
+     */
+    Object.defineProperty(globalThis.SVGElement.prototype, 'checkVisibility', {
+        writable: true,
+        value: function () {
+            const bbox = this.getBBox();
+            return bbox.width > 0 && bbox.height > 0;
+        },
+    });
+
 });

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -162,7 +162,7 @@ beforeEach(() => {
      */
     Object.defineProperty(globalThis.SVGElement.prototype, 'getBBox', {
         writable: true,
-        value: jest.fn().mockImplementation(createSVGRect)
+        value: jest.fn().mockImplementation(createSVGRect),
     });
 
 });

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -23,6 +23,15 @@ Object.defineProperty(window, 'SVGAngle', {
 
 beforeEach(()=>{
 
+    Object.defineProperty(global, 'ResizeObserver', {
+      writable: true,
+      value: jest.fn().mockImplementation(() => ({
+          observe: jest.fn(),
+          unobserve: jest.fn(),
+          disconnect: jest.fn()
+      }))
+    });
+
     Object.defineProperty(global.SVGSVGElement.prototype, 'createSVGMatrix', {
       writable: true,
       value: jest.fn().mockImplementation(() => ({
@@ -54,7 +63,7 @@ beforeEach(()=>{
         })),
       })),
     });
-  
+
     Object.defineProperty(global.SVGSVGElement.prototype, 'createSVGPoint', {
       writable: true,
       value: jest.fn().mockImplementation(() => ({
@@ -66,7 +75,7 @@ beforeEach(()=>{
         })),
       })),
     });
-  
+
     Object.defineProperty(global.SVGSVGElement.prototype, 'createSVGTransform', {
       writable: true,
       value: jest.fn().mockImplementation(() => ({
@@ -84,5 +93,4 @@ beforeEach(()=>{
         setTranslate: jest.fn(),
       })),
     });
-
 });

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -4,6 +4,86 @@
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom/extend-expect';
 
+// Interfaces
+// ----------
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGAngle
+ */
+const createSVGAngle = () => ({
+    SVG_ANGLETYPE_UNKNOWN: 0,
+    SVG_ANGLETYPE_UNSPECIFIED: 1,
+    SVG_ANGLETYPE_DEG: 2,
+    SVG_ANGLETYPE_RAD: 3,
+    SVG_ANGLETYPE_GRAD: 4,
+});
+
+/**
+ * @description SVGMatrix is deprecated, we should use DOMMatrix instead
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGMatrix
+ */
+const createSVGMatrix = () => ({
+    a: 0,
+    b: 0,
+    c: 0,
+    d: 0,
+    e: 0,
+    f: 0,
+    flipX: jest.fn().mockImplementation(createSVGMatrix),
+    flipY: jest.fn().mockImplementation(createSVGMatrix),
+    inverse: jest.fn().mockImplementation(createSVGMatrix),
+    multiply: jest.fn().mockImplementation(createSVGMatrix),
+    rotate: jest.fn().mockImplementation(createSVGMatrix),
+    rotateFromVector: jest.fn().mockImplementation(createSVGMatrix),
+    scale: jest.fn().mockImplementation(createSVGMatrix),
+    scaleNonUniform: jest.fn().mockImplementation(createSVGMatrix),
+    skewX: jest.fn().mockImplementation(createSVGMatrix),
+    skewY: jest.fn().mockImplementation(createSVGMatrix),
+    translate: jest.fn().mockImplementation(createSVGMatrix),
+});
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGTransform
+ */
+const createSVGTransform = () => ({
+    type: 0,
+    angle: 0,
+    matrix: createSVGMatrix(),
+    SVG_TRANSFORM_UNKNOWN: 0,
+    SVG_TRANSFORM_MATRIX: 1,
+    SVG_TRANSFORM_TRANSLATE: 2,
+    SVG_TRANSFORM_SCALE: 3,
+    SVG_TRANSFORM_ROTATE: 4,
+    SVG_TRANSFORM_SKEWX: 5,
+    SVG_TRANSFORM_SKEWY: 6,
+    setMatrix: jest.fn(),
+    setRotate: jest.fn(),
+    setScale: jest.fn(),
+    setSkewX: jest.fn(),
+    setSkewY: jest.fn(),
+    setTranslate: jest.fn(),
+});
+
+/**
+ * @description SVGPoint is deprecated, we should use DOMPoint instead
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGPoint
+ */
+const createSVGPoint = () => ({
+    x: 0,
+    y: 0,
+    matrixTransform: jest.fn().mockImplementation(createSVGPoint),
+});
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGRect
+ */
+const createSVGRect = () => ({
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0,
+});
+
 // Mocks
 // -----
 
@@ -19,7 +99,7 @@ globalThis.SVGPathElement = jest.fn();
  */
 Object.defineProperty(globalThis, 'SVGAngle', {
     writable: true,
-    value: jest.fn().mockImplementation(() => SVGAngle),
+    value: jest.fn().mockImplementation(createSVGAngle),
 });
 
 beforeEach(() => {
@@ -38,7 +118,7 @@ beforeEach(() => {
      */
     Object.defineProperty(globalThis.SVGSVGElement.prototype, 'createSVGMatrix', {
         writable: true,
-        value: jest.fn().mockImplementation(() => SVGMatrix),
+        value: jest.fn().mockImplementation(createSVGMatrix),
     });
 
     /**
@@ -46,7 +126,7 @@ beforeEach(() => {
      */
     Object.defineProperty(globalThis.SVGSVGElement.prototype, 'createSVGTransform', {
         writable: true,
-        value: jest.fn().mockImplementation(() => SVGTransform),
+        value: jest.fn().mockImplementation(createSVGTransform),
     });
 
     /**
@@ -54,7 +134,7 @@ beforeEach(() => {
      */
     Object.defineProperty(globalThis.SVGSVGElement.prototype, 'createSVGPoint', {
         writable: true,
-        value: jest.fn().mockImplementation(() => SVGPoint),
+        value: jest.fn().mockImplementation(createSVGPoint),
     });
 
     /**
@@ -73,7 +153,7 @@ beforeEach(() => {
      */
     Object.defineProperty(globalThis.SVGElement.prototype, 'getScreenCTM', {
         writable: true,
-        value: jest.fn().mockImplementation(() => SVGMatrix),
+        value: jest.fn().mockImplementation(createSVGMatrix),
     });
 
     /**
@@ -82,86 +162,7 @@ beforeEach(() => {
      */
     Object.defineProperty(globalThis.SVGElement.prototype, 'getBBox', {
         writable: true,
-        value: jest.fn().mockImplementation(() => SVGRect)
+        value: jest.fn().mockImplementation(createSVGRect)
     });
 
-});
-
-// Interfaces
-// ----------
-
-/**
- * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGAngle
- */
-const SVGAngle = ({
-    SVG_ANGLETYPE_UNKNOWN: 0,
-    SVG_ANGLETYPE_UNSPECIFIED: 1,
-    SVG_ANGLETYPE_DEG: 2,
-    SVG_ANGLETYPE_RAD: 3,
-    SVG_ANGLETYPE_GRAD: 4,
-});
-
-/**
- * @description SVGMatrix is deprecated, we should use DOMMatrix instead
- * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGMatrix
- */
-const SVGMatrix = ({
-    a: 0,
-    b: 0,
-    c: 0,
-    d: 0,
-    e: 0,
-    f: 0,
-    flipX: jest.fn().mockImplementation(() => SVGMatrix),
-    flipY: jest.fn().mockImplementation(() => SVGMatrix),
-    inverse: jest.fn().mockImplementation(() => SVGMatrix),
-    multiply: jest.fn().mockImplementation(() => SVGMatrix),
-    rotate: jest.fn().mockImplementation(() => SVGMatrix),
-    rotateFromVector: jest.fn().mockImplementation(() => SVGMatrix),
-    scale: jest.fn().mockImplementation(() => SVGMatrix),
-    scaleNonUniform: jest.fn().mockImplementation(() => SVGMatrix),
-    skewX: jest.fn().mockImplementation(() => SVGMatrix),
-    skewY: jest.fn().mockImplementation(() => SVGMatrix),
-    translate: jest.fn().mockImplementation(() => SVGMatrix),
-});
-
-/**
- * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGTransform
- */
-const SVGTransform = ({
-    type: 0,
-    angle: 0,
-    matrix: SVGMatrix,
-    SVG_TRANSFORM_UNKNOWN: 0,
-    SVG_TRANSFORM_MATRIX: 1,
-    SVG_TRANSFORM_TRANSLATE: 2,
-    SVG_TRANSFORM_SCALE: 3,
-    SVG_TRANSFORM_ROTATE: 4,
-    SVG_TRANSFORM_SKEWX: 5,
-    SVG_TRANSFORM_SKEWY: 6,
-    setMatrix: jest.fn(),
-    setRotate: jest.fn(),
-    setScale: jest.fn(),
-    setSkewX: jest.fn(),
-    setSkewY: jest.fn(),
-    setTranslate: jest.fn(),
-});
-
-/**
- * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGPoint
- */
-const SVGPoint = ({
-    x: 0,
-    y: 0,
-    matrixTransform: jest.fn().mockImplementation(() => SVGPoint),
-});
-
-/**
- * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGRect
- */
-const SVGRect = ({
-    x: 0,
-    y: 0,
-    width: 0,
-    height: 0,
 });

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -2,95 +2,166 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/extend-expect';
 
-// Mock method which is not implemented in JSDOM
-window.SVGPathElement = jest.fn();
+// Mocks
+// -----
 
-// Mock SVGAngle which is used for sanity checks in Vectorizer library
-Object.defineProperty(window, 'SVGAngle', {
-  writable: true,
-  value: jest.fn().mockImplementation(() => ({
-      new: jest.fn(),
-      prototype: jest.fn(),
-      SVG_ANGLETYPE_UNKNOWN: 0,
-      SVG_ANGLETYPE_UNSPECIFIED: 1,
-      SVG_ANGLETYPE_DEG: 2,
-      SVG_ANGLETYPE_RAD: 3,
-      SVG_ANGLETYPE_GRAD: 4
-  }))
+/**
+ * @description Mock method which is not implemented in JSDOM
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGPathElement
+ */
+globalThis.SVGPathElement = jest.fn();
+
+/**
+ * @description Mock SVGAngle which is used for sanity checks in Vectorizer library
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGAngle
+ */
+Object.defineProperty(globalThis, 'SVGAngle', {
+    writable: true,
+    value: jest.fn().mockImplementation(() => SVGAngle),
 });
 
-beforeEach(()=>{
+beforeEach(() => {
 
-    Object.defineProperty(global, 'ResizeObserver', {
-      writable: true,
-      value: jest.fn().mockImplementation(() => ({
-          observe: jest.fn(),
-          unobserve: jest.fn(),
-          disconnect: jest.fn()
-      }))
+    /**
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver
+     */
+    globalThis.ResizeObserver = jest.fn().mockImplementation(() => ({
+        observe: jest.fn(),
+        unobserve: jest.fn(),
+        disconnect: jest.fn(),
+    }));
+
+    /**
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGSVGElement/createSVGMatrix
+     */
+    Object.defineProperty(globalThis.SVGSVGElement.prototype, 'createSVGMatrix', {
+        writable: true,
+        value: jest.fn().mockImplementation(() => SVGMatrix),
     });
 
-    Object.defineProperty(global.SVGSVGElement.prototype, 'createSVGMatrix', {
-      writable: true,
-      value: jest.fn().mockImplementation(() => ({
-        martix: jest.fn(() => [[]]),
-        a: 0,
-        b: 0,
-        c: 0,
-        d: 0,
-        e: 0,
-        f: 0,
-        flipX: jest.fn().mockImplementation(() => global.SVGSVGElement),
-        flipY: jest.fn().mockImplementation(() => global.SVGSVGElement),
-        inverse: jest.fn().mockImplementation(() => global.SVGSVGElement),
-        multiply: jest.fn().mockImplementation(() => global.SVGSVGElement),
-        rotate: jest.fn().mockImplementation(() => ({
-          translate: jest.fn().mockImplementation(() => ({
-            rotate: jest.fn(),
-          })),
-        })),
-        rotateFromVector: jest.fn().mockImplementation(() => global.SVGSVGElement),
-        scale: jest.fn().mockImplementation(() => global.SVGSVGElement),
-        scaleNonUniform: jest.fn().mockImplementation(() => global.SVGSVGElement),
-        skewX: jest.fn().mockImplementation(() => global.SVGSVGElement),
-        skewY: jest.fn().mockImplementation(() => global.SVGSVGElement),
-        translate: jest.fn().mockImplementation(() => ({
-          multiply: jest.fn().mockImplementation(() => ({
-            multiply: jest.fn().mockImplementation(() => global.SVGSVGElement),
-          })),
-        })),
-      })),
+    /**
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGTransform
+     */
+    Object.defineProperty(globalThis.SVGSVGElement.prototype, 'createSVGTransform', {
+        writable: true,
+        value: jest.fn().mockImplementation(() => SVGTransform),
     });
 
-    Object.defineProperty(global.SVGSVGElement.prototype, 'createSVGPoint', {
-      writable: true,
-      value: jest.fn().mockImplementation(() => ({
-        x: 0,
-        y: 0,
-        matrixTransform: jest.fn().mockImplementation(() => ({
-          x: 0,
-          y: 0,
-        })),
-      })),
+    /**
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGPoint
+     */
+    Object.defineProperty(globalThis.SVGSVGElement.prototype, 'createSVGPoint', {
+        writable: true,
+        value: jest.fn().mockImplementation(() => SVGPoint),
     });
 
-    Object.defineProperty(global.SVGSVGElement.prototype, 'createSVGTransform', {
-      writable: true,
-      value: jest.fn().mockImplementation(() => ({
-        angle: 0,
-        matrix: {
-          a: 1,
-          b: 0,
-          c: 0,
-          d: 1,
-          e: 0,
-          f: 0,
-          multiply: jest.fn(),
-        },
-        setMatrix: jest.fn(),
-        setTranslate: jest.fn(),
-      })),
+    /**
+     * @description used in `util.breakText()` method
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGTextContentElement/getComputedTextLength
+     */
+    Object.defineProperty(globalThis.SVGElement.prototype, 'getComputedTextLength', {
+        writable: true,
+        value: jest.fn().mockImplementation(() => 0),
     });
+
+    /**
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGGraphicsElement/getScreenCTM
+     * Note: JSDOM SVGGraphicsElement does not encompass all SVG elements that might be needed,
+     * whereas SVGElement provides broader compatibility.
+     */
+    Object.defineProperty(globalThis.SVGElement.prototype, 'getScreenCTM', {
+        writable: true,
+        value: jest.fn().mockImplementation(() => SVGMatrix),
+    });
+
+    /**
+     * @description used in `util.breakText()` method
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGGraphicsElement/getBBox
+     */
+    Object.defineProperty(globalThis.SVGElement.prototype, 'getBBox', {
+        writable: true,
+        value: jest.fn().mockImplementation(() => SVGRect)
+    });
+
+});
+
+// Interfaces
+// ----------
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGAngle
+ */
+const SVGAngle = ({
+    SVG_ANGLETYPE_UNKNOWN: 0,
+    SVG_ANGLETYPE_UNSPECIFIED: 1,
+    SVG_ANGLETYPE_DEG: 2,
+    SVG_ANGLETYPE_RAD: 3,
+    SVG_ANGLETYPE_GRAD: 4,
+});
+
+/**
+ * @description SVGMatrix is deprecated, we should use DOMMatrix instead
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGMatrix
+ */
+const SVGMatrix = ({
+    a: 0,
+    b: 0,
+    c: 0,
+    d: 0,
+    e: 0,
+    f: 0,
+    flipX: jest.fn().mockImplementation(() => SVGMatrix),
+    flipY: jest.fn().mockImplementation(() => SVGMatrix),
+    inverse: jest.fn().mockImplementation(() => SVGMatrix),
+    multiply: jest.fn().mockImplementation(() => SVGMatrix),
+    rotate: jest.fn().mockImplementation(() => SVGMatrix),
+    rotateFromVector: jest.fn().mockImplementation(() => SVGMatrix),
+    scale: jest.fn().mockImplementation(() => SVGMatrix),
+    scaleNonUniform: jest.fn().mockImplementation(() => SVGMatrix),
+    skewX: jest.fn().mockImplementation(() => SVGMatrix),
+    skewY: jest.fn().mockImplementation(() => SVGMatrix),
+    translate: jest.fn().mockImplementation(() => SVGMatrix),
+});
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGTransform
+ */
+const SVGTransform = ({
+    type: 0,
+    angle: 0,
+    matrix: SVGMatrix,
+    SVG_TRANSFORM_UNKNOWN: 0,
+    SVG_TRANSFORM_MATRIX: 1,
+    SVG_TRANSFORM_TRANSLATE: 2,
+    SVG_TRANSFORM_SCALE: 3,
+    SVG_TRANSFORM_ROTATE: 4,
+    SVG_TRANSFORM_SKEWX: 5,
+    SVG_TRANSFORM_SKEWY: 6,
+    setMatrix: jest.fn(),
+    setRotate: jest.fn(),
+    setScale: jest.fn(),
+    setSkewX: jest.fn(),
+    setSkewY: jest.fn(),
+    setTranslate: jest.fn(),
+});
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGPoint
+ */
+const SVGPoint = ({
+    x: 0,
+    y: 0,
+    matrixTransform: jest.fn().mockImplementation(() => SVGPoint),
+});
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGRect
+ */
+const SVGRect = ({
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0,
 });

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -179,4 +179,27 @@ beforeEach(() => {
         },
     });
 
+    /**
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGTransformList
+     * @description SVGElement.transform.baseVal is not implemented in JSDOM yet.
+     */
+    Object.defineProperty(globalThis.SVGElement.prototype, 'transform', {
+        writable: true,
+        value: {
+            baseVal: {
+                numberOfItems: 0,
+                length: 0,
+                appendItem: jest.fn().mockImplementation(createSVGTransform),
+                clear: jest.fn(),
+                consolidate: jest.fn().mockImplementation(createSVGTransform),
+                getItem: jest.fn().mockImplementation(() => createSVGTransform()),
+                initialize: jest.fn().mockImplementation(createSVGTransform),
+                insertItemBefore: jest.fn().mockImplementation(createSVGTransform),
+                removeItem: jest.fn().mockImplementation(createSVGTransform),
+                replaceItem: jest.fn().mockImplementation(createSVGTransform),
+                createSVGTransformFromMatrix: jest.fn().mockImplementation(createSVGTransform),
+            }
+        }
+    });
+
 });


### PR DESCRIPTION
Uses latest mocks from https://github.com/clientIO/joint/blob/master/packages/joint-vitest-plugin-mock-svg/mocks/index.ts, fixed for Jest:
- The `fn().mockImplementation(() => SVGMatrix)` pattern (where `const SVGMatrix = ({...});`) is replaced by `fn().mockImplementation(createSVGMatrix)` (where `const createSVGMatrix = () => ({...});`).